### PR TITLE
Implement plan 2026-03-13_09-50_upgrade-symfony-deps-phpstan6-phpunit…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.3', '8.4', '8.5']
+        symfony-version: ['6.4.*', '7.*', '8.*']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist --with-all-dependencies symfony/*:${{ matrix.symfony-version }}
+
+      - name: Composer install
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c phpunit.xml.dist
+
+      - name: Fixture app cache clear
+        run: php tests/fixture-app/bin/console cache:clear --env=test --no-interaction
+
+      - name: Fixture app type registry generation
+        run: php tests/fixture-app/bin/console flexible_graphql:generate-type-registry --env=test --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,16 @@
   "require": {
     "php": "^8.3",
     "axtiva/flexible-graphql-php": "^3.0",
+    "symfony/console": "^6.4 | ^7.0 | ^8.0",
     "symfony/config": "^6.4 | ^7.0 | ^8.0",
     "symfony/dependency-injection": "^6.4 | ^7.0 | ^8.0",
     "symfony/framework-bundle": "^6.4 | ^7.0 | ^8.0",
-    "symfony/property-access": "^6.4 | ^7.0 | ^8.0"
+    "symfony/http-kernel": "^6.4 | ^7.0 | ^8.0",
+    "symfony/property-access": "^6.4 | ^7.0 | ^8.0",
+    "symfony/yaml": "^6.4 | ^7.0 | ^8.0"
   },
   "require-dev": {
-    "symfony/console": "^6.4 | ^7.0 | ^8.0",
+    "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^12"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+  level: 6
+  paths:
+    - src
+    - tests
+  excludePaths:
+    analyse:
+      - tests/fixture-app/var/*
+  tmpDir: var/phpstan

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true">
+    <testsuites>
+        <testsuite name="bundle">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="0"/>
+    </php>
+</phpunit>

--- a/src/Command/GenerateDirectiveResolverCommand.php
+++ b/src/Command/GenerateDirectiveResolverCommand.php
@@ -17,18 +17,16 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'flexible_graphql:generate-directive-resolver')]
 class GenerateDirectiveResolverCommand extends Command
 {
-    protected static $defaultName = 'flexible_graphql:generate-directive-resolver';
+    protected static ?string $defaultName = 'flexible_graphql:generate-directive-resolver';
     private string $schemaFiles;
     private CodeGeneratorBuilderInterface $codeGeneratorBuilder;
 
     public function __construct(
         string $schemaFiles,
-        string $schemaType,
         CodeGeneratorBuilderInterface $codeGeneratorBuilder
     ) {
         parent::__construct();
         $this->schemaFiles = $schemaFiles;
-        $this->schemaType = $schemaType;
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }
 
@@ -46,7 +44,6 @@ class GenerateDirectiveResolverCommand extends Command
         $io->title('Read schema SDL from ' . $this->schemaFiles);
         $schema = SchemaBuilder::build($this->schemaFiles);
         $codeGenerator = $this->codeGeneratorBuilder->build();
-        /** @var Directive $directive */
         $directiveName = $input->getArgument('directive_name');
         $directive = $schema->getDirective($directiveName);
         if (empty($directive)) {

--- a/src/Command/GenerateFieldResolverCommand.php
+++ b/src/Command/GenerateFieldResolverCommand.php
@@ -17,18 +17,16 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'flexible_graphql:generate-field-resolver')]
 class GenerateFieldResolverCommand extends Command
 {
-    protected static $defaultName = 'flexible_graphql:generate-field-resolver';
+    protected static ?string $defaultName = 'flexible_graphql:generate-field-resolver';
     private string $schemaFiles;
     private CodeGeneratorBuilderInterface $codeGeneratorBuilder;
 
     public function __construct(
         string $schemaFiles,
-        string $schemaType,
         CodeGeneratorBuilderInterface $codeGeneratorBuilder
     ) {
         parent::__construct();
         $this->schemaFiles = $schemaFiles;
-        $this->schemaType = $schemaType;
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }
 
@@ -54,11 +52,12 @@ class GenerateFieldResolverCommand extends Command
             $io->error('Type did not found in schema ' . $typeName);
             return Command::FAILURE;
         }
-        $field = $type->getField($fieldName);
-        if (empty($field)) {
+        if (! $type->hasField($fieldName)) {
             $io->error('Field did not found in type ' . $fieldName);
             return Command::FAILURE;
         }
+
+        $field = $type->getField($fieldName);
 
         $io->success('Field resolver generated');
         foreach ($codeGenerator->generateFieldResolver($type, $field, $schema) as $code) {

--- a/src/Command/GenerateScalarResolverCommand.php
+++ b/src/Command/GenerateScalarResolverCommand.php
@@ -17,19 +17,16 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'flexible_graphql:generate-scalar-resolver')]
 class GenerateScalarResolverCommand extends Command
 {
-    protected static $defaultName = 'flexible_graphql:generate-scalar-resolver';
+    protected static ?string $defaultName = 'flexible_graphql:generate-scalar-resolver';
     private string $schemaFiles;
-    private string $schemaType;
     private CodeGeneratorBuilderInterface $codeGeneratorBuilder;
 
     public function __construct(
         string $schemaFiles,
-        string $schemaType,
         CodeGeneratorBuilderInterface $codeGeneratorBuilder
     ) {
         parent::__construct();
         $this->schemaFiles = $schemaFiles;
-        $this->schemaType = $schemaType;
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }
 
@@ -47,10 +44,9 @@ class GenerateScalarResolverCommand extends Command
         $io->title('Read schema SDL from ' . $this->schemaFiles);
         $schema = SchemaBuilder::build($this->schemaFiles);
         $codeGenerator = $this->codeGeneratorBuilder->build();
-        /** @var CustomScalarType $scalar */
         $scalarName = $input->getArgument('custom_scalar_name');
         $scalar = $schema->getType($scalarName);
-        if (empty($scalar)) {
+        if (! $scalar instanceof CustomScalarType) {
             $io->error('Scalar did not found in schema ' . $scalarName);
             return Command::FAILURE;
         }

--- a/src/Command/GenerateTypeRegistryCommand.php
+++ b/src/Command/GenerateTypeRegistryCommand.php
@@ -16,21 +16,18 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'flexible_graphql:generate-type-registry')]
 class GenerateTypeRegistryCommand extends Command
 {
-    protected static $defaultName = 'flexible_graphql:generate-type-registry';
+    protected static ?string $defaultName = 'flexible_graphql:generate-type-registry';
     private string $schemaFiles;
-    private string $schemaType;
     private TypeRegistryGeneratorBuilderInterface $typeRegistryGeneratorBuilder;
     private CodeGeneratorBuilderInterface $codeGeneratorBuilder;
 
     public function __construct(
         string $schemaFiles,
-        string $schemaType,
         TypeRegistryGeneratorBuilderInterface $typeRegistryGeneratorBuilder,
         CodeGeneratorBuilderInterface $codeGeneratorBuilder
     ) {
         parent::__construct();
         $this->schemaFiles = $schemaFiles;
-        $this->schemaType = $schemaType;
         $this->typeRegistryGeneratorBuilder = $typeRegistryGeneratorBuilder;
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -56,7 +56,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('schema_type', 'enum');
 
-        /** @var EnumNodeDefinition $node */
+        /** @var EnumNodeDefinition<null> $node */
         $node = $treeBuilder->getRootNode();
 
         $node
@@ -72,7 +72,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('executor', 'enum');
 
-        /** @var EnumNodeDefinition $node */
+        /** @var EnumNodeDefinition<null> $node */
         $node = $treeBuilder->getRootNode();
 
         $node
@@ -88,7 +88,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('enable_preload', 'boolean');
 
-        /** @var BooleanNodeDefinition $node */
+        /** @var BooleanNodeDefinition<null> $node */
         $node = $treeBuilder->getRootNode();
 
         $node
@@ -129,7 +129,11 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function addScalar(string $name, $default = null, string $info = null): ScalarNodeDefinition
+    private function addScalar(
+        string $name,
+        string|int|float|bool|null $default = null,
+        ?string $info = null
+    ): ScalarNodeDefinition
     {
         $builder = new TreeBuilder($name, 'scalar');
 

--- a/src/DependencyInjection/FlexibleGraphqlExtension.php
+++ b/src/DependencyInjection/FlexibleGraphqlExtension.php
@@ -46,8 +46,12 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
     public const _ENTITIES_RESOLVER_TAG = 'flexible_graphql._entities_resolver';
     public const FEDERATION_REPRESENTATION_RESOLVER_TAG = 'flexible_graphql.federation_representation_resolver';
 
+    /** @var array<string, mixed> */
     private array $config;
 
+    /**
+     * @param array<mixed> $config
+     */
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new Configuration();
@@ -56,7 +60,10 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
     /**
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    /**
+     * @param array<array<mixed>> $configs
+     */
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $yamlLoader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $yamlLoader->load('services.yaml');
@@ -73,7 +80,7 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
     /**
      * @return void
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->registerResolvers($this->config, $container);
         if ($this->config['schema_type'] === Configuration::SCHEMA_TYPE_FEDERATION) {
@@ -86,7 +93,10 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         return Configuration::NAME;
     }
 
-    private function registerResolvers(array $config, ContainerBuilder $container)
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function registerResolvers(array $config, ContainerBuilder $container): void
     {
         if (!file_exists($config['dir'])) {
             mkdir($config['dir'], 0755, true);
@@ -137,6 +147,9 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         }
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function setCompilerCacheWarmer(array $config, ContainerBuilder $container): void
     {
         $container->register(SchemaCacheWarmer::class)
@@ -149,6 +162,9 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
             ->addTag('kernel.cache_warmer', ['priority' => 50]);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function registerConfigGenerator(array $config, ContainerBuilder $container): void
     {
         $container->register(CodeGeneratorConfigInterface::class)
@@ -158,6 +174,9 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
             ->setArgument('$namespace', $config['namespace']);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function registerTypeRegistryGenerator(array $config, ContainerBuilder $container): void
     {
         $baseTypeRegistryClass = $config['schema_type'] === Configuration::SCHEMA_TYPE_FEDERATION
@@ -188,6 +207,9 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         );
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function registerCodeGenerator(array $config, ContainerBuilder $container): void
     {
         if ($config['schema_type'] === Configuration::SCHEMA_TYPE_FEDERATION) {
@@ -201,12 +223,14 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         }
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function registerCommands(array $config, ContainerBuilder $container): void
     {
         $container->register(GenerateTypeRegistryCommand::class)
             ->setArguments([
                 $config['schema_files'],
-                $config['schema_type'],
                 new Reference(TypeRegistryGeneratorBuilderInterface::class),
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
@@ -215,7 +239,6 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         $container->register(GenerateDirectiveResolverCommand::class)
             ->setArguments([
                 $config['schema_files'],
-                $config['schema_type'],
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
             ->addTag('console.command', ['command' => GenerateDirectiveResolverCommand::getDefaultName()]);
@@ -223,7 +246,6 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         $container->register(GenerateFieldResolverCommand::class)
             ->setArguments([
                 $config['schema_files'],
-                $config['schema_type'],
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
             ->addTag('console.command', ['command' => GenerateFieldResolverCommand::getDefaultName()]);
@@ -231,12 +253,14 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
         $container->register(GenerateScalarResolverCommand::class)
             ->setArguments([
                 $config['schema_files'],
-                $config['schema_type'],
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
             ->addTag('console.command', ['command' => GenerateScalarResolverCommand::getDefaultName()]);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function registerRepresentationResolver(array $config, ContainerBuilder $container): void
     {
         if ($container->findTaggedServiceIds(self::_ENTITIES_RESOLVER_TAG)) {
@@ -265,7 +289,10 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
                     $schema = '';
                     foreach (glob($config['schema_files']) as $fsElement) {
                         if (is_file($fsElement)) {
-                            $schema .= file_get_contents($fsElement) . PHP_EOL;
+                            $content = file_get_contents($fsElement);
+                            if ($content !== false) {
+                                $schema .= $content . PHP_EOL;
+                            }
                         }
                     }
                     $definition->setArgument('$graphqlSchemaSDL', $schema);

--- a/src/Resolver/DefaultResolver.php
+++ b/src/Resolver/DefaultResolver.php
@@ -7,18 +7,19 @@ namespace Axtiva\FlexibleGraphqlBundle\Resolver;
 use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\ResolveInfo;
 use Axtiva\FlexibleGraphql\Resolver\ResolverInterface;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
+use ArrayAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class DefaultResolver implements ResolverInterface
 {
-    private PropertyAccessor $propertyAccessor;
+    private PropertyAccessorInterface $propertyAccessor;
 
-    public function __construct(PropertyAccessor $propertyAccessor)
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
     {
         $this->propertyAccessor = $propertyAccessor;
     }
 
-    public function __invoke($rootValue, $args, $context, ResolveInfo $info)
+    public function __invoke(mixed $rootValue, array|ArrayAccess|null $args, mixed $context, ResolveInfo $info): mixed
     {
         $property = Executor::defaultFieldResolver($rootValue, $args, $context, $info);
 

--- a/tests/E2e/FixtureAppConsoleTest.php
+++ b/tests/E2e/FixtureAppConsoleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axtiva\FlexibleGraphqlBundle\Tests\E2e;
+
+use PHPUnit\Framework\TestCase;
+
+final class FixtureAppConsoleTest extends TestCase
+{
+    public function testFixtureAppGenerationFlows(): void
+    {
+        $fixtureAppDir = self::fixtureAppDir();
+        $generatedDir = $fixtureAppDir . '/var/generated';
+        $registryFile = $generatedDir . '/TypeRegistry.php';
+
+        if (!is_dir($generatedDir)) {
+            mkdir($generatedDir, 0755, true);
+        }
+
+        if (is_file($registryFile)) {
+            unlink($registryFile);
+        }
+
+        $this->runConsoleCommand('cache:clear');
+        self::assertFileExists($registryFile, 'cache:clear must trigger schema cache warmer generation');
+
+        unlink($registryFile);
+
+        $output = $this->runConsoleCommand('flexible_graphql:generate-type-registry');
+        self::assertStringContainsString($registryFile, $output);
+        self::assertFileExists($registryFile);
+    }
+
+    private static function fixtureAppDir(): string
+    {
+        return dirname(__DIR__) . '/fixture-app';
+    }
+
+    private function runConsoleCommand(string $command): string
+    {
+        $fixtureAppDir = self::fixtureAppDir();
+        $consolePath = $fixtureAppDir . '/bin/console';
+        $execCommand = sprintf(
+            'php %s --env=test --no-interaction %s 2>&1',
+            escapeshellarg($consolePath),
+            escapeshellarg($command)
+        );
+
+        $output = [];
+        $exitCode = 1;
+        exec($execCommand, $output, $exitCode);
+
+        self::assertSame(0, $exitCode, implode(PHP_EOL, $output));
+
+        return implode(PHP_EOL, $output);
+    }
+}

--- a/tests/fixture-app/bin/console
+++ b/tests/fixture-app/bin/console
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require dirname(__DIR__) . '/src/Kernel.php';
+
+$input = new ArgvInput();
+$environment = (string) $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');
+$debug = (bool) ($_SERVER['APP_DEBUG'] ?? ($environment !== 'prod'));
+
+$kernel = new Kernel($environment, $debug);
+$application = new Application($kernel);
+$application->run($input);

--- a/tests/fixture-app/config/bundles.php
+++ b/tests/fixture-app/config/bundles.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Axtiva\FlexibleGraphqlBundle\FlexibleGraphqlBundle::class => ['all' => true],
+];

--- a/tests/fixture-app/config/graphql/schema.graphql
+++ b/tests/fixture-app/config/graphql/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  ping: String!
+}

--- a/tests/fixture-app/config/packages/flexible_graphql.php
+++ b/tests/fixture-app/config/packages/flexible_graphql.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('flexible_graphql', [
+        'namespace' => 'App\\GraphQL',
+        'dir' => '%kernel.project_dir%/var/generated',
+        'schema_type' => 'graphql',
+        'schema_files' => '%kernel.project_dir%/config/graphql/*.graphql',
+        'enable_preload' => false,
+        'default_resolver' => 'flexible_graphql.default_resolver',
+        'template_language_version' => '8.3',
+    ]);
+};

--- a/tests/fixture-app/config/packages/framework.php
+++ b/tests/fixture-app/config/packages/framework.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('framework', [
+        'secret' => 'test-secret',
+        'test' => true,
+        'http_method_override' => false,
+    ]);
+};

--- a/tests/fixture-app/config/reference.php
+++ b/tests/fixture-app/config/reference.php
@@ -1,0 +1,813 @@
+<?php
+
+// This file is auto-generated and is for apps only. Bundles SHOULD NOT rely on its content.
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Config\Loader\ParamConfigurator as Param;
+
+/**
+ * This class provides array-shapes for configuring the services and bundles of an application.
+ *
+ * Services declared with the config() method below are autowired and autoconfigured by default.
+ *
+ * This is for apps only. Bundles SHOULD NOT use it.
+ *
+ * Example:
+ *
+ *     ```php
+ *     // config/services.php
+ *     namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+ *
+ *     return App::config([
+ *         'services' => [
+ *             'App\\' => [
+ *                 'resource' => '../src/',
+ *             ],
+ *         ],
+ *     ]);
+ *     ```
+ *
+ * @psalm-type ImportsConfig = list<string|array{
+ *     resource: string,
+ *     type?: string|null,
+ *     ignore_errors?: bool,
+ * }>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
+ * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
+ * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
+ * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
+ * @psalm-type CallbackType = string|array{0:string|ReferenceConfigurator,1:string}|\Closure|ReferenceConfigurator
+ * @psalm-type DeprecationType = array{package: string, version: string, message?: string}
+ * @psalm-type DefaultsType = array{
+ *     public?: bool,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     autowire?: bool,
+ *     autoconfigure?: bool,
+ *     bind?: array<string, mixed>,
+ * }
+ * @psalm-type InstanceofType = array{
+ *     shared?: bool,
+ *     lazy?: bool|string,
+ *     public?: bool,
+ *     properties?: array<string, mixed>,
+ *     configurator?: CallbackType,
+ *     calls?: list<CallType>,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     autowire?: bool,
+ *     bind?: array<string, mixed>,
+ *     constructor?: string,
+ * }
+ * @psalm-type DefinitionType = array{
+ *     class?: string,
+ *     file?: string,
+ *     parent?: string,
+ *     shared?: bool,
+ *     synthetic?: bool,
+ *     lazy?: bool|string,
+ *     public?: bool,
+ *     abstract?: bool,
+ *     deprecated?: DeprecationType,
+ *     factory?: CallbackType,
+ *     configurator?: CallbackType,
+ *     arguments?: ArgumentsType,
+ *     properties?: array<string, mixed>,
+ *     calls?: list<CallType>,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     decorates?: string,
+ *     decoration_inner_name?: string,
+ *     decoration_priority?: int,
+ *     decoration_on_invalid?: 'exception'|'ignore'|null,
+ *     autowire?: bool,
+ *     autoconfigure?: bool,
+ *     bind?: array<string, mixed>,
+ *     constructor?: string,
+ *     from_callable?: CallbackType,
+ * }
+ * @psalm-type AliasType = string|array{
+ *     alias: string,
+ *     public?: bool,
+ *     deprecated?: DeprecationType,
+ * }
+ * @psalm-type PrototypeType = array{
+ *     resource: string,
+ *     namespace?: string,
+ *     exclude?: string|list<string>,
+ *     parent?: string,
+ *     shared?: bool,
+ *     lazy?: bool|string,
+ *     public?: bool,
+ *     abstract?: bool,
+ *     deprecated?: DeprecationType,
+ *     factory?: CallbackType,
+ *     arguments?: ArgumentsType,
+ *     properties?: array<string, mixed>,
+ *     configurator?: CallbackType,
+ *     calls?: list<CallType>,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     autowire?: bool,
+ *     autoconfigure?: bool,
+ *     bind?: array<string, mixed>,
+ *     constructor?: string,
+ * }
+ * @psalm-type StackType = array{
+ *     stack: list<DefinitionType|AliasType|PrototypeType|array<class-string, ArgumentsType|null>>,
+ *     public?: bool,
+ *     deprecated?: DeprecationType,
+ * }
+ * @psalm-type ServicesConfig = array{
+ *     _defaults?: DefaultsType,
+ *     _instanceof?: InstanceofType,
+ *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
+ * }
+ * @psalm-type ExtensionType = array<string, mixed>
+ * @psalm-type FrameworkConfig = array{
+ *     secret?: scalar|Param|null,
+ *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
+ *     allowed_http_method_override?: list<string|Param>|null,
+ *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
+ *     test?: bool|Param,
+ *     default_locale?: scalar|Param|null, // Default: "en"
+ *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
+ *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
+ *     enabled_locales?: list<scalar|Param|null>,
+ *     trusted_hosts?: list<scalar|Param|null>,
+ *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
+ *     trusted_headers?: list<scalar|Param|null>,
+ *     error_controller?: scalar|Param|null, // Default: "error_controller"
+ *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
+ *     csrf_protection?: bool|array{
+ *         enabled?: scalar|Param|null, // Default: null
+ *         stateless_token_ids?: list<scalar|Param|null>,
+ *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *     },
+ *     form?: bool|array{ // Form configuration
+ *         enabled?: bool|Param, // Default: false
+ *         csrf_protection?: bool|array{
+ *             enabled?: scalar|Param|null, // Default: null
+ *             token_id?: scalar|Param|null, // Default: null
+ *             field_name?: scalar|Param|null, // Default: "_token"
+ *             field_attr?: array<string, scalar|Param|null>,
+ *         },
+ *     },
+ *     http_cache?: bool|array{ // HTTP cache configuration
+ *         enabled?: bool|Param, // Default: false
+ *         debug?: bool|Param, // Default: "%kernel.debug%"
+ *         trace_level?: "none"|"short"|"full"|Param,
+ *         trace_header?: scalar|Param|null,
+ *         default_ttl?: int|Param,
+ *         private_headers?: list<scalar|Param|null>,
+ *         skip_response_headers?: list<scalar|Param|null>,
+ *         allow_reload?: bool|Param,
+ *         allow_revalidate?: bool|Param,
+ *         stale_while_revalidate?: int|Param,
+ *         stale_if_error?: int|Param,
+ *         terminate_on_cache_hit?: bool|Param,
+ *     },
+ *     esi?: bool|array{ // ESI configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     ssi?: bool|array{ // SSI configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     fragments?: bool|array{ // Fragments configuration
+ *         enabled?: bool|Param, // Default: false
+ *         hinclude_default_template?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Default: "/_fragment"
+ *     },
+ *     profiler?: bool|array{ // Profiler configuration
+ *         enabled?: bool|Param, // Default: false
+ *         collect?: bool|Param, // Default: true
+ *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         only_exceptions?: bool|Param, // Default: false
+ *         only_main_requests?: bool|Param, // Default: false
+ *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
+ *         collect_serializer_data?: bool|Param, // Enables the serializer data collector and profiler panel. // Default: false
+ *     },
+ *     workflows?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         workflows?: array<string, array{ // Default: []
+ *             audit_trail?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *             },
+ *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
+ *             marking_store?: array{
+ *                 type?: "method"|Param,
+ *                 property?: scalar|Param|null,
+ *                 service?: scalar|Param|null,
+ *             },
+ *             supports?: list<scalar|Param|null>,
+ *             definition_validators?: list<scalar|Param|null>,
+ *             support_strategy?: scalar|Param|null,
+ *             initial_marking?: list<scalar|Param|null>,
+ *             events_to_dispatch?: list<string|Param>|null,
+ *             places?: list<array{ // Default: []
+ *                 name?: scalar|Param|null,
+ *                 metadata?: array<string, mixed>,
+ *             }>,
+ *             transitions?: list<array{ // Default: []
+ *                 name?: string|Param,
+ *                 guard?: string|Param, // An expression to block the transition.
+ *                 from?: list<array{ // Default: []
+ *                     place?: string|Param,
+ *                     weight?: int|Param, // Default: 1
+ *                 }>,
+ *                 to?: list<array{ // Default: []
+ *                     place?: string|Param,
+ *                     weight?: int|Param, // Default: 1
+ *                 }>,
+ *                 weight?: int|Param, // Default: 1
+ *                 metadata?: array<string, mixed>,
+ *             }>,
+ *             metadata?: array<string, mixed>,
+ *         }>,
+ *     },
+ *     router?: bool|array{ // Router configuration
+ *         enabled?: bool|Param, // Default: false
+ *         resource?: scalar|Param|null,
+ *         type?: scalar|Param|null,
+ *         cache_dir?: scalar|Param|null, // Deprecated: Setting the "framework.router.cache_dir.cache_dir" configuration option is deprecated. It will be removed in version 8.0. // Default: "%kernel.build_dir%"
+ *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|Param|null, // Default: 80
+ *         https_port?: scalar|Param|null, // Default: 443
+ *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         utf8?: bool|Param, // Default: true
+ *     },
+ *     session?: bool|array{ // Session configuration
+ *         enabled?: bool|Param, // Default: false
+ *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|Param|null,
+ *         cookie_lifetime?: scalar|Param|null,
+ *         cookie_path?: scalar|Param|null,
+ *         cookie_domain?: scalar|Param|null,
+ *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
+ *         cookie_httponly?: bool|Param, // Default: true
+ *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *         use_cookies?: bool|Param,
+ *         gc_divisor?: scalar|Param|null,
+ *         gc_probability?: scalar|Param|null,
+ *         gc_maxlifetime?: scalar|Param|null,
+ *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
+ *         sid_length?: int|Param, // Deprecated: Setting the "framework.session.sid_length.sid_length" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
+ *         sid_bits_per_character?: int|Param, // Deprecated: Setting the "framework.session.sid_bits_per_character.sid_bits_per_character" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
+ *     },
+ *     request?: bool|array{ // Request configuration
+ *         enabled?: bool|Param, // Default: false
+ *         formats?: array<string, string|list<scalar|Param|null>>,
+ *     },
+ *     assets?: bool|array{ // Assets configuration
+ *         enabled?: bool|Param, // Default: false
+ *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *         version_strategy?: scalar|Param|null, // Default: null
+ *         version?: scalar|Param|null, // Default: null
+ *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|Param|null, // Default: null
+ *         base_path?: scalar|Param|null, // Default: ""
+ *         base_urls?: list<scalar|Param|null>,
+ *         packages?: array<string, array{ // Default: []
+ *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *             version_strategy?: scalar|Param|null, // Default: null
+ *             version?: scalar|Param|null,
+ *             version_format?: scalar|Param|null, // Default: null
+ *             json_manifest_path?: scalar|Param|null, // Default: null
+ *             base_path?: scalar|Param|null, // Default: ""
+ *             base_urls?: list<scalar|Param|null>,
+ *         }>,
+ *     },
+ *     asset_mapper?: bool|array{ // Asset Mapper configuration
+ *         enabled?: bool|Param, // Default: false
+ *         paths?: array<string, scalar|Param|null>,
+ *         excluded_patterns?: list<scalar|Param|null>,
+ *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
+ *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
+ *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
+ *         extensions?: array<string, scalar|Param|null>,
+ *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|Param|null>,
+ *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
+ *             enabled?: bool|Param, // Default: false
+ *             formats?: list<scalar|Param|null>,
+ *             extensions?: list<scalar|Param|null>,
+ *         },
+ *     },
+ *     translator?: bool|array{ // Translator configuration
+ *         enabled?: bool|Param, // Default: false
+ *         fallbacks?: list<scalar|Param|null>,
+ *         logging?: bool|Param, // Default: false
+ *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|Param|null>,
+ *         pseudo_localization?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             accents?: bool|Param, // Default: true
+ *             expansion_factor?: float|Param, // Default: 1.0
+ *             brackets?: bool|Param, // Default: true
+ *             parse_html?: bool|Param, // Default: false
+ *             localizable_html_attributes?: list<scalar|Param|null>,
+ *         },
+ *         providers?: array<string, array{ // Default: []
+ *             dsn?: scalar|Param|null,
+ *             domains?: list<scalar|Param|null>,
+ *             locales?: list<scalar|Param|null>,
+ *         }>,
+ *         globals?: array<string, string|array{ // Default: []
+ *             value?: mixed,
+ *             message?: string|Param,
+ *             parameters?: array<string, scalar|Param|null>,
+ *             domain?: string|Param,
+ *         }>,
+ *     },
+ *     validation?: bool|array{ // Validation configuration
+ *         enabled?: bool|Param, // Default: false
+ *         cache?: scalar|Param|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
+ *         enable_attributes?: bool|Param, // Default: true
+ *         static_method?: list<scalar|Param|null>,
+ *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
+ *         mapping?: array{
+ *             paths?: list<scalar|Param|null>,
+ *         },
+ *         not_compromised_password?: bool|array{
+ *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
+ *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *         },
+ *         disable_translation?: bool|Param, // Default: false
+ *         auto_mapping?: array<string, array{ // Default: []
+ *             services?: list<scalar|Param|null>,
+ *         }>,
+ *     },
+ *     annotations?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     serializer?: bool|array{ // Serializer configuration
+ *         enabled?: bool|Param, // Default: false
+ *         enable_attributes?: bool|Param, // Default: true
+ *         name_converter?: scalar|Param|null,
+ *         circular_reference_handler?: scalar|Param|null,
+ *         max_depth_handler?: scalar|Param|null,
+ *         mapping?: array{
+ *             paths?: list<scalar|Param|null>,
+ *         },
+ *         default_context?: array<string, mixed>,
+ *         named_serializers?: array<string, array{ // Default: []
+ *             name_converter?: scalar|Param|null,
+ *             default_context?: array<string, mixed>,
+ *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
+ *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
+ *         }>,
+ *     },
+ *     property_access?: bool|array{ // Property access configuration
+ *         enabled?: bool|Param, // Default: true
+ *         magic_call?: bool|Param, // Default: false
+ *         magic_get?: bool|Param, // Default: true
+ *         magic_set?: bool|Param, // Default: true
+ *         throw_exception_on_invalid_index?: bool|Param, // Default: false
+ *         throw_exception_on_invalid_property_path?: bool|Param, // Default: true
+ *     },
+ *     type_info?: bool|array{ // Type info configuration
+ *         enabled?: bool|Param, // Default: true
+ *         aliases?: array<string, scalar|Param|null>,
+ *     },
+ *     property_info?: bool|array{ // Property info configuration
+ *         enabled?: bool|Param, // Default: true
+ *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor.
+ *     },
+ *     cache?: array{ // Cache configuration
+ *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|Param|null,
+ *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|Param|null, // Default: null
+ *         pools?: array<string, array{ // Default: []
+ *             adapters?: list<scalar|Param|null>,
+ *             tags?: scalar|Param|null, // Default: null
+ *             public?: bool|Param, // Default: false
+ *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
+ *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|Param|null,
+ *             clearer?: scalar|Param|null,
+ *         }>,
+ *     },
+ *     php_errors?: array{ // PHP errors handling configuration
+ *         log?: mixed, // Use the application logger instead of the PHP logger for logging PHP errors. // Default: true
+ *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
+ *     },
+ *     exceptions?: array<string, array{ // Default: []
+ *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *     }>,
+ *     web_link?: bool|array{ // Web links configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     lock?: bool|string|array{ // Lock configuration
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: array<string, string|list<scalar|Param|null>>,
+ *     },
+ *     semaphore?: bool|string|array{ // Semaphore configuration
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: array<string, scalar|Param|null>,
+ *     },
+ *     messenger?: bool|array{ // Messenger configuration
+ *         enabled?: bool|Param, // Default: false
+ *         routing?: array<string, string|array{ // Default: []
+ *             senders?: list<scalar|Param|null>,
+ *         }>,
+ *         serializer?: array{
+ *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             symfony_serializer?: array{
+ *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 context?: array<string, mixed>,
+ *             },
+ *         },
+ *         transports?: array<string, string|array{ // Default: []
+ *             dsn?: scalar|Param|null,
+ *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
+ *             options?: array<string, mixed>,
+ *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             retry_strategy?: string|array{
+ *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
+ *             },
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *         }>,
+ *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: list<scalar|Param|null>,
+ *         default_bus?: scalar|Param|null, // Default: null
+ *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
+ *             default_middleware?: bool|string|array{
+ *                 enabled?: bool|Param, // Default: true
+ *                 allow_no_handlers?: bool|Param, // Default: false
+ *                 allow_no_senders?: bool|Param, // Default: true
+ *             },
+ *             middleware?: list<string|array{ // Default: []
+ *                 id?: scalar|Param|null,
+ *                 arguments?: list<mixed>,
+ *             }>,
+ *         }>,
+ *     },
+ *     scheduler?: bool|array{ // Scheduler configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     disallow_search_engine_index?: bool|Param, // Enabled by default when debug is enabled. // Default: true
+ *     http_client?: bool|array{ // HTTP Client configuration
+ *         enabled?: bool|Param, // Default: false
+ *         max_host_connections?: int|Param, // The maximum number of connections to a single host.
+ *         default_options?: array{
+ *             headers?: array<string, mixed>,
+ *             vars?: array<string, mixed>,
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
+ *                 sha1?: mixed,
+ *                 pin-sha256?: mixed,
+ *                 md5?: mixed,
+ *             },
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             extra?: array<string, mixed>,
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             caching?: bool|array{ // Caching configuration.
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *             },
+ *             retry_failed?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: array<string, array{ // Default: []
+ *                     code?: int|Param,
+ *                     methods?: list<string|Param>,
+ *                 }>,
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *             },
+ *         },
+ *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         scoped_clients?: array<string, string|array{ // Default: []
+ *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|Param|null>,
+ *             headers?: array<string, mixed>,
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
+ *                 sha1?: mixed,
+ *                 pin-sha256?: mixed,
+ *                 md5?: mixed,
+ *             },
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             extra?: array<string, mixed>,
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             caching?: bool|array{ // Caching configuration.
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *             },
+ *             retry_failed?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: array<string, array{ // Default: []
+ *                     code?: int|Param,
+ *                     methods?: list<string|Param>,
+ *                 }>,
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *             },
+ *         }>,
+ *     },
+ *     mailer?: bool|array{ // Mailer configuration
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|Param|null, // Default: null
+ *         transports?: array<string, scalar|Param|null>,
+ *         envelope?: array{ // Mailer Envelope configuration
+ *             sender?: scalar|Param|null,
+ *             recipients?: list<scalar|Param|null>,
+ *             allowed_recipients?: list<scalar|Param|null>,
+ *         },
+ *         headers?: array<string, string|array{ // Default: []
+ *             value?: mixed,
+ *         }>,
+ *         dkim_signer?: bool|array{ // DKIM signer configuration
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|Param|null, // Default: ""
+ *             select?: scalar|Param|null, // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
+ *             options?: array<string, mixed>,
+ *         },
+ *         smime_signer?: bool|array{ // S/MIME signer configuration
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|Param|null, // Default: null
+ *             sign_options?: int|Param, // Default: null
+ *         },
+ *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
+ *             enabled?: bool|Param, // Default: false
+ *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
+ *         },
+ *     },
+ *     secrets?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
+ *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *     },
+ *     notifier?: bool|array{ // Notifier configuration
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|Param|null>,
+ *         texter_transports?: array<string, scalar|Param|null>,
+ *         notification_on_failed_messages?: bool|Param, // Default: false
+ *         channel_policy?: array<string, string|list<scalar|Param|null>>,
+ *         admin_recipients?: list<array{ // Default: []
+ *             email?: scalar|Param|null,
+ *             phone?: scalar|Param|null, // Default: ""
+ *         }>,
+ *     },
+ *     rate_limiter?: bool|array{ // Rate limiter configuration
+ *         enabled?: bool|Param, // Default: false
+ *         limiters?: array<string, array{ // Default: []
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: list<scalar|Param|null>,
+ *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
+ *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
+ *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
+ *             },
+ *         }>,
+ *     },
+ *     uid?: bool|array{ // Uid configuration
+ *         enabled?: bool|Param, // Default: false
+ *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
+ *         name_based_uuid_version?: 5|3|Param, // Default: 5
+ *         name_based_uuid_namespace?: scalar|Param|null,
+ *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
+ *         time_based_uuid_node?: scalar|Param|null,
+ *     },
+ *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
+ *         enabled?: bool|Param, // Default: false
+ *         sanitizers?: array<string, array{ // Default: []
+ *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
+ *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
+ *             allow_elements?: array<string, mixed>,
+ *             block_elements?: list<string|Param>,
+ *             drop_elements?: list<string|Param>,
+ *             allow_attributes?: array<string, mixed>,
+ *             drop_attributes?: array<string, mixed>,
+ *             force_attributes?: array<string, array<string, string|Param>>,
+ *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
+ *             allowed_link_schemes?: list<string|Param>,
+ *             allowed_link_hosts?: list<string|Param>|null,
+ *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
+ *             allowed_media_schemes?: list<string|Param>,
+ *             allowed_media_hosts?: list<string|Param>|null,
+ *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
+ *             with_attribute_sanitizers?: list<string|Param>,
+ *             without_attribute_sanitizers?: list<string|Param>,
+ *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
+ *         }>,
+ *     },
+ *     webhook?: bool|array{ // Webhook configuration
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         routing?: array<string, array{ // Default: []
+ *             service?: scalar|Param|null,
+ *             secret?: scalar|Param|null, // Default: ""
+ *         }>,
+ *     },
+ *     remote-event?: bool|array{ // RemoteEvent configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     json_streamer?: bool|array{ // JSON streamer configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ * }
+ * @psalm-type FlexibleGraphqlConfig = array{
+ *     schema_type?: "graphql"|"federation"|Param, // Select what type of schema use, common or federated // Default: "graphql"
+ *     schema_files?: scalar|Param|null, // Full path to schema sdl files like /path/to/schema.graphql or glob template // Default: "%kernel.project_dir%/config/graphql/*.graphql"
+ *     executor?: "sync"|"amphp_v2"|"amphp_v3"|Param, // Select executor type for graphql operations // Default: "sync"
+ *     enable_preload?: bool|Param, // Enable usage type registry on opcache.preload file // Default: true
+ *     default_resolver?: scalar|Param|null, // Default resolver for common cases // Default: "flexible_graphql.default_resolver"
+ *     namespace?: scalar|Param|null, // Root namespace for generated code // Default: "App\\GraphQL"
+ *     template_language_version?: scalar|Param|null, // PHP version of templates for php code // Default: "7.4"
+ *     dir?: scalar|Param|null, // Root dir for generated code // Default: "%kernel.project_dir%/src/GraphQL/"
+ * }
+ * @psalm-type ConfigType = array{
+ *     imports?: ImportsConfig,
+ *     parameters?: ParametersConfig,
+ *     services?: ServicesConfig,
+ *     framework?: FrameworkConfig,
+ *     flexible_graphql?: FlexibleGraphqlConfig,
+ *     "when@dev"?: array{
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         framework?: FrameworkConfig,
+ *         flexible_graphql?: FlexibleGraphqlConfig,
+ *     },
+ *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         ...<string, ExtensionType>,
+ *     }>
+ * }
+ */
+final class App
+{
+    /**
+     * @param ConfigType $config
+     *
+     * @psalm-return ConfigType
+     */
+    public static function config(array $config): array
+    {
+        /** @var ConfigType $config */
+        $config = AppReference::config($config);
+
+        return $config;
+    }
+}
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+/**
+ * This class provides array-shapes for configuring the routes of an application.
+ *
+ * Example:
+ *
+ *     ```php
+ *     // config/routes.php
+ *     namespace Symfony\Component\Routing\Loader\Configurator;
+ *
+ *     return Routes::config([
+ *         'controllers' => [
+ *             'resource' => 'routing.controllers',
+ *         ],
+ *     ]);
+ *     ```
+ *
+ * @psalm-type RouteConfig = array{
+ *     path: string|array<string,string>,
+ *     controller?: string,
+ *     methods?: string|list<string>,
+ *     requirements?: array<string,string>,
+ *     defaults?: array<string,mixed>,
+ *     options?: array<string,mixed>,
+ *     host?: string|array<string,string>,
+ *     schemes?: string|list<string>,
+ *     condition?: string,
+ *     locale?: string,
+ *     format?: string,
+ *     utf8?: bool,
+ *     stateless?: bool,
+ * }
+ * @psalm-type ImportConfig = array{
+ *     resource: string,
+ *     type?: string,
+ *     exclude?: string|list<string>,
+ *     prefix?: string|array<string,string>,
+ *     name_prefix?: string,
+ *     trailing_slash_on_root?: bool,
+ *     controller?: string,
+ *     methods?: string|list<string>,
+ *     requirements?: array<string,string>,
+ *     defaults?: array<string,mixed>,
+ *     options?: array<string,mixed>,
+ *     host?: string|array<string,string>,
+ *     schemes?: string|list<string>,
+ *     condition?: string,
+ *     locale?: string,
+ *     format?: string,
+ *     utf8?: bool,
+ *     stateless?: bool,
+ * }
+ * @psalm-type AliasConfig = array{
+ *     alias: string,
+ *     deprecated?: array{package:string, version:string, message?:string},
+ * }
+ * @psalm-type RoutesConfig = array{
+ *     "when@dev"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
+ *     ...<string, RouteConfig|ImportConfig|AliasConfig>
+ * }
+ */
+final class Routes
+{
+    /**
+     * @param RoutesConfig $config
+     *
+     * @psalm-return RoutesConfig
+     */
+    public static function config(array $config): array
+    {
+        return $config;
+    }
+}

--- a/tests/fixture-app/config/services.php
+++ b/tests/fixture-app/config/services.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('App\\', '../src/');
+};

--- a/tests/fixture-app/src/Kernel.php
+++ b/tests/fixture-app/src/Kernel.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+final class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        $bundles = require $this->getProjectDir() . '/config/bundles.php';
+
+        foreach ($bundles as $class => $envs) {
+            if (($envs[$this->environment] ?? $envs['all'] ?? false) === true) {
+                yield new $class();
+            }
+        }
+    }
+
+    public function getProjectDir(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->import('../config/packages/*.php');
+        $container->import('../config/services.php');
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+    }
+}


### PR DESCRIPTION
…12-ci

isFinished: Yes

Implemented tooling/compatibility upgrade end-to-end: updated Symfony dependency hygiene in composer.json (moved symfony/console to require, added symfony/http-kernel and symfony/yaml, added phpstan/phpstan), added PHPStan level 6 config (phpstan.neon.dist), added PHPUnit 12 config (phpunit.xml.dist), created fixture Symfony app + E2E test to exercise cache warmer and type registry generation (tests/E2e/FixtureAppConsoleTest.php, tests/fixture-app/**), and added CI matrix workflow (.github/workflows/ci.yml) for PHP 8.3/8.4/8.5 × Symfony 6.4/7/8. Verified with composer install, phpstan, phpunit, and direct fixture console commands.

Raw feedback:
{
  "feedback": {
    "approve": true,
    "summary": "Implemented tooling/compatibility upgrade end-to-end: updated Symfony dependency hygiene in composer.json (moved symfony/console to require, added symfony/http-kernel and symfony/yaml, added phpstan/phpstan), added PHPStan level 6 config (phpstan.neon.dist), added PHPUnit 12 config (phpunit.xml.dist), created fixture Symfony app + E2E test to exercise cache warmer and type registry generation (tests/E2e/FixtureAppConsoleTest.php, tests/fixture-app/**), and added CI matrix workflow (.github/workflows/ci.yml) for PHP 8.3/8.4/8.5 × Symfony 6.4/7/8. Verified with composer install, phpstan, phpunit, and direct fixture console commands."
  },
  "plan": {
    "id": "2026-03-13_09-50_upgrade-symfony-deps-phpstan6-phpunit12-ci",
    "assumptions": [
      "No docker wrapper is available in this repository, so verification was executed directly with local PHP/Composer.",
      "Matrix uses Symfony version constraints (6.4.*, 7.*, 8.*) via composer update in CI to validate cross-version compatibility in a bundle repo.",
      "Fixture app runtime config uses minimal FrameworkBundle + bundle wiring sufficient to execute cache:clear and flexible_graphql:generate-type-registry."
    ],
    "risks": [
      "Some CI matrix combinations may depend on upstream package/platform availability at runtime (not fully reproducible locally).",
      "FlexibleGraphqlExtension still relies on existing compiler-pass registration behavior already present in repo patterns."
    ]
  },
  "changes": {
    "files_changed": [
      "composer.json",
      "src/Command/GenerateDirectiveResolverCommand.php",
      "src/Command/GenerateFieldResolverCommand.php",
      "src/Command/GenerateScalarResolverCommand.php",
      "src/Command/GenerateTypeRegistryCommand.php",
      "src/DependencyInjection/Configuration.php",
      "src/DependencyInjection/FlexibleGraphqlExtension.php",
      "src/Resolver/DefaultResolver.php"
    ],
    "files_added": [
      ".github/workflows/ci.yml",
      "phpstan.neon.dist",
      "phpunit.xml.dist",
      "tests/E2e/FixtureAppConsoleTest.php",
      "tests/fixture-app/bin/console",
      "tests/fixture-app/src/Kernel.php",
      "tests/fixture-app/config/bundles.php",
      "tests/fixture-app/config/packages/framework.php",
      "tests/fixture-app/config/packages/flexible_graphql.php",
      "tests/fixture-app/config/services.php",
      "tests/fixture-app/config/graphql/schema.graphql",
      "docs/retro.md"
    ],
    "notes": [
      "Direct Symfony component requirements now explicitly cover imported runtime surfaces (http-kernel, console, dependency-injection loader path).",
      "PHPStan config contains no ignoreErrors/baseline/suppressions and is green at level 6.",
      "PHPUnit uses an in-repo fixture app to run real Symfony console flows and assert generated TypeRegistry file behavior.",
      "CI workflow includes composer update per Symfony target, composer install, phpstan, phpunit, and explicit fixture command validations."
    ]
  },
  "verification": {
    "commands": [
      {
        "cmd": "composer install --no-interaction --prefer-dist",
        "ok": true,
        "note": "Dependencies install successfully with current lock state."
      },
      {
        "cmd": "vendor/bin/phpstan analyse -c phpstan.neon.dist",
        "ok": true,
        "note": "Passes at level 6 with zero ignored/suppressed errors."
      },
      {
        "cmd": "vendor/bin/phpunit -c phpunit.xml.dist",
        "ok": true,
        "note": "Passes (1 test, 5 assertions), including fixture-app generation flow."
      },
      {
        "cmd": "php tests/fixture-app/bin/console cache:clear",
        "ok": true,
        "note": "Exercises SchemaCacheWarmer::warmUp() through Symfony cache clear."
      },
      {
        "cmd": "php tests/fixture-app/bin/console flexible_graphql:generate-type-registry",
        "ok": true,
        "note": "Exercises GenerateTypeRegistryCommand::execute(), prints and writes TypeRegistry path."
      }
    ],
    "could_not_run": []
  },
  "retro": {
    "written": true,
    "path": "docs/retro.md"
  },
  "blockers": []
}