### PR TITLE
Implement plan 2026-03-13_11-17_ci-tests-scoped-service-locator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - name: Install dependencies
-        run: composer update --no-interaction --prefer-dist --with-all-dependencies symfony/*:${{ matrix.symfony-version }}
-
       - name: Composer install
         run: composer install --no-interaction --prefer-dist
+
+      - name: Install Symfony matrix dependencies
+        run: composer update --no-interaction --prefer-dist --with-all-dependencies symfony/*:${{ matrix.symfony-version }}
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,11 +27,16 @@ flexible_graphql:
   default_resolver: flexible_graphql.default_resolver # default resolver if it does not defined
 ```
 
-## Define container as service
+## Use scoped TypeRegistry locator
 
 ```yaml
 services:
-  Psr\Container\ContainerInterface: '@service_container'
+  # Provided by the bundle. Used by generated TypeRegistry constructor.
+  flexible_graphql.type_registry.service_locator: ~
+
+  App\GraphQL\TypeRegistry:
+    arguments:
+      $locator: '@flexible_graphql.type_registry.service_locator'
 ```
 
 ## Run code generation with warmup command

--- a/src/Builder/ScopedTypeRegistryGeneratorBuilder.php
+++ b/src/Builder/ScopedTypeRegistryGeneratorBuilder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axtiva\FlexibleGraphqlBundle\Builder;
+
+use Axtiva\FlexibleGraphql\Builder\TypeRegistryGeneratorBuilderInterface;
+use Axtiva\FlexibleGraphql\Generator\TypeRegistry\TypeRegistryGeneratorInterface;
+use Axtiva\FlexibleGraphqlBundle\Generator\ScopedServiceCollectionTypeRegistryGenerator;
+
+final class ScopedTypeRegistryGeneratorBuilder implements TypeRegistryGeneratorBuilderInterface
+{
+    public function __construct(
+        private readonly TypeRegistryGeneratorBuilderInterface $baseBuilder,
+    ) {
+    }
+
+    public function build(): TypeRegistryGeneratorInterface
+    {
+        return new ScopedServiceCollectionTypeRegistryGenerator($this->baseBuilder->build());
+    }
+}

--- a/src/DependencyInjection/FlexibleGraphqlExtension.php
+++ b/src/DependencyInjection/FlexibleGraphqlExtension.php
@@ -16,11 +16,7 @@ use Axtiva\FlexibleGraphql\Generator\Config\CodeGeneratorConfigInterface;
 use Axtiva\FlexibleGraphql\Generator\Config\Foundation\Psr4\CodeGeneratorConfig;
 use Axtiva\FlexibleGraphql\Resolver\_EntitiesResolverInterface;
 use Axtiva\FlexibleGraphql\Resolver\_ServiceResolverInterface;
-use Axtiva\FlexibleGraphql\Resolver\CustomScalarResolverInterface;
-use Axtiva\FlexibleGraphql\Resolver\DirectiveResolverInterface;
-use Axtiva\FlexibleGraphql\Resolver\FederationRepresentationResolverInterface;
-use Axtiva\FlexibleGraphql\Resolver\ResolverInterface;
-use Axtiva\FlexibleGraphql\Resolver\UnionResolveTypeInterface;
+use Axtiva\FlexibleGraphqlBundle\Builder\ScopedTypeRegistryGeneratorBuilder;
 use Axtiva\FlexibleGraphqlBundle\CacheWarmer\SchemaCacheWarmer;
 use Axtiva\FlexibleGraphqlBundle\Command\GenerateDirectiveResolverCommand;
 use Axtiva\FlexibleGraphqlBundle\Command\GenerateFieldResolverCommand;
@@ -30,7 +26,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -45,6 +40,10 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
     public const _SERVICE_RESOLVER_TAG = 'flexible_graphql._service_resolver';
     public const _ENTITIES_RESOLVER_TAG = 'flexible_graphql._entities_resolver';
     public const FEDERATION_REPRESENTATION_RESOLVER_TAG = 'flexible_graphql.federation_representation_resolver';
+    public const TYPE_REGISTRY_SERVICE_TAG = 'flexible_graphql.type_registry.service';
+
+    private const BASE_TYPE_REGISTRY_BUILDER_ID = 'flexible_graphql.type_registry_generator.base_builder';
+    private const SELECTED_TYPE_REGISTRY_BUILDER_ID = 'flexible_graphql.type_registry_generator.selected_builder';
 
     /** @var array<string, mixed> */
     private array $config;
@@ -82,7 +81,7 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
      */
     public function process(ContainerBuilder $container): void
     {
-        $this->registerResolvers($this->config, $container);
+        $this->ensureOutputDir($this->config);
         if ($this->config['schema_type'] === Configuration::SCHEMA_TYPE_FEDERATION) {
             $this->registerRepresentationResolver($this->config, $container);
         }
@@ -96,54 +95,10 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
     /**
      * @param array<string, mixed> $config
      */
-    private function registerResolvers(array $config, ContainerBuilder $container): void
+    private function ensureOutputDir(array $config): void
     {
         if (!file_exists($config['dir'])) {
             mkdir($config['dir'], 0755, true);
-        }
-
-        $defaultDefinition = new Definition();
-        $defaultDefinition->setAutoconfigured(true);
-
-        foreach ($container->getDefinitions() as $id => $definition) {
-            $reflection = $container->getReflectionClass($id, false);
-            if ($reflection !== null) {
-                if ($reflection->isSubclassOf(ResolverInterface::class)) {
-                    $definition
-                        ->addTag(static::RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-                if ($reflection->isSubclassOf(DirectiveResolverInterface::class)) {
-                    $definition
-                        ->addTag(static::DIRECTIVE_RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-                if ($reflection->isSubclassOf(CustomScalarResolverInterface::class)) {
-                    $definition
-                        ->addTag(static::SCALAR_RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-                if ($reflection->isSubclassOf(UnionResolveTypeInterface::class)) {
-                    $definition
-                        ->addTag(static::UNION_TYPE_RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-                if ($reflection->isSubclassOf(FederationRepresentationResolverInterface::class)) {
-                    $definition
-                        ->addTag(static::FEDERATION_REPRESENTATION_RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-                if ($reflection->isSubclassOf(_ServiceResolverInterface::class)) {
-                    $definition
-                        ->addTag(static::_SERVICE_RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-                if ($reflection->isSubclassOf(_EntitiesResolverInterface::class)) {
-                    $definition
-                        ->addTag(static::_ENTITIES_RESOLVER_TAG)
-                        ->setPublic(true);
-                }
-            }
         }
     }
 
@@ -183,23 +138,44 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
             ? TypeRegistryGeneratorBuilderFederated::class
             : TypeRegistryGeneratorBuilder::class
         ;
-        $container->register($baseTypeRegistryClass)
+
+        $defaultResolverServiceId = (string) $config['default_resolver'];
+        if ($container->hasAlias($defaultResolverServiceId)) {
+            $defaultResolverServiceId = (string) $container->getAlias($defaultResolverServiceId);
+        }
+
+        $container->register(self::BASE_TYPE_REGISTRY_BUILDER_ID)
+            ->setClass($baseTypeRegistryClass)
             ->setArgument('$config', new Reference(CodeGeneratorConfigInterface::class));
+
+        if ($container->hasDefinition($defaultResolverServiceId)) {
+            $container
+                ->getDefinition(self::BASE_TYPE_REGISTRY_BUILDER_ID)
+                ->addMethodCall('setDefaultFieldResolverServiceName', [$defaultResolverServiceId]);
+
+            $container
+                ->getDefinition($defaultResolverServiceId)
+                ->addTag(self::TYPE_REGISTRY_SERVICE_TAG);
+        }
 
         if ($config['executor'] === Configuration::EXECUTOR_TYPE_SYNC) {
             $container->setAlias(
-                TypeRegistryGeneratorBuilderInterface::class,
-                $baseTypeRegistryClass
+                self::SELECTED_TYPE_REGISTRY_BUILDER_ID,
+                self::BASE_TYPE_REGISTRY_BUILDER_ID
             );
         } elseif($config['executor'] === Configuration::EXECUTOR_TYPE_ASYNC_AMPHPV2) {
-            $container->register(TypeRegistryGeneratorBuilderInterface::class)
+            $container->register(self::SELECTED_TYPE_REGISTRY_BUILDER_ID)
                 ->setClass(TypeRegistryGeneratorBuilderAmphpV2::class)
-                ->setArgument('$baseBuilder', new Reference($baseTypeRegistryClass));
+                ->setArgument('$baseBuilder', new Reference(self::BASE_TYPE_REGISTRY_BUILDER_ID));
         } elseif($config['executor'] === Configuration::EXECUTOR_TYPE_ASYNC_AMPHPV3) {
-            $container->register(TypeRegistryGeneratorBuilderInterface::class)
+            $container->register(self::SELECTED_TYPE_REGISTRY_BUILDER_ID)
                 ->setClass(TypeRegistryGeneratorBuilderAmphp::class)
-                ->setArgument('$baseBuilder', new Reference($baseTypeRegistryClass));
+                ->setArgument('$baseBuilder', new Reference(self::BASE_TYPE_REGISTRY_BUILDER_ID));
         }
+
+        $container->register(TypeRegistryGeneratorBuilderInterface::class)
+            ->setClass(ScopedTypeRegistryGeneratorBuilder::class)
+            ->setArgument('$baseBuilder', new Reference(self::SELECTED_TYPE_REGISTRY_BUILDER_ID));
 
         $container->setAlias(
             'flexible_graphql.type_registry_generator.builder',

--- a/src/FlexibleGraphqlBundle.php
+++ b/src/FlexibleGraphqlBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Axtiva\FlexibleGraphqlBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/Generator/ScopedServiceCollectionTypeRegistryGenerator.php
+++ b/src/Generator/ScopedServiceCollectionTypeRegistryGenerator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axtiva\FlexibleGraphqlBundle\Generator;
+
+use Axtiva\FlexibleGraphql\Generator\Config\TypeRegistryGeneratorConfigInterface;
+use Axtiva\FlexibleGraphql\Generator\TypeRegistry\TypeRegistryGeneratorInterface;
+use GraphQL\Type\Schema;
+
+final class ScopedServiceCollectionTypeRegistryGenerator implements TypeRegistryGeneratorInterface
+{
+    public function __construct(
+        private readonly TypeRegistryGeneratorInterface $baseGenerator,
+    ) {
+    }
+
+    public function getConfig(): TypeRegistryGeneratorConfigInterface
+    {
+        return $this->baseGenerator->getConfig();
+    }
+
+    public function generate(Schema $schema): string
+    {
+        $generatedCode = $this->baseGenerator->generate($schema);
+        $generatedCode = str_replace(
+            'use Psr\\Container\\ContainerInterface;',
+            'use Symfony\\Contracts\\Service\\ServiceCollectionInterface;',
+            $generatedCode
+        );
+
+        $generatedCode = str_replace(
+            'private ContainerInterface $container;',
+            'private readonly ServiceCollectionInterface $locator;',
+            $generatedCode
+        );
+
+        $generatedCode = str_replace(
+            'public function __construct(ContainerInterface $container)',
+            'public function __construct(ServiceCollectionInterface $locator)',
+            $generatedCode
+        );
+
+        $generatedCode = str_replace(
+            '$this->container = $container;',
+            '$this->locator = $locator;',
+            $generatedCode
+        );
+
+        return str_replace(
+            '$service = $this->container->get($id);',
+            '$service = $this->locator->get($id);',
+            $generatedCode
+        );
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -3,9 +3,50 @@ services:
     autowire: true
     autoconfigure: true
 
+  _instanceof:
+    Axtiva\FlexibleGraphql\Resolver\ResolverInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql.resolver' }
+        - { name: 'flexible_graphql.type_registry.service' }
+
+    Axtiva\FlexibleGraphql\Resolver\DirectiveResolverInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql.directive_resolver' }
+        - { name: 'flexible_graphql.type_registry.service' }
+
+    Axtiva\FlexibleGraphql\Resolver\CustomScalarResolverInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql.scalar_resolver' }
+        - { name: 'flexible_graphql.type_registry.service' }
+
+    Axtiva\FlexibleGraphql\Resolver\UnionResolveTypeInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql.union_type_resolver' }
+        - { name: 'flexible_graphql.type_registry.service' }
+
+    Axtiva\FlexibleGraphql\Resolver\FederationRepresentationResolverInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql.federation_representation_resolver' }
+
+    Axtiva\FlexibleGraphql\Resolver\_ServiceResolverInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql._service_resolver' }
+
+    Axtiva\FlexibleGraphql\Resolver\_EntitiesResolverInterface:
+      public: true
+      tags:
+        - { name: 'flexible_graphql._entities_resolver' }
+
   Axtiva\FlexibleGraphqlBundle\Resolver\DefaultResolver:
     arguments:
       $propertyAccessor: '@flexible_graphql.property_accessor'
+
   flexible_graphql.default_resolver:
     alias: 'Axtiva\FlexibleGraphqlBundle\Resolver\DefaultResolver'
     public: true
@@ -20,3 +61,9 @@ services:
     class: Symfony\Component\PropertyAccess\PropertyAccessorInterface
     factory: ['@flexible_graphql.property_accessor_builder', 'getPropertyAccessor']
 
+  flexible_graphql.type_registry.service_locator:
+    class: Symfony\Component\DependencyInjection\ServiceLocator
+    tags: ['container.service_locator']
+    arguments:
+      - !tagged_iterator { tag: 'flexible_graphql.type_registry.service', index_by: 'service_id' }
+    public: true

--- a/tests/DependencyInjection/FlexibleGraphqlExtensionTest.php
+++ b/tests/DependencyInjection/FlexibleGraphqlExtensionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axtiva\FlexibleGraphqlBundle\Tests\DependencyInjection;
+
+use Axtiva\FlexibleGraphql\Builder\Foundation\Psr\Container\TypeRegistryGeneratorBuilder;
+use Axtiva\FlexibleGraphql\Builder\Foundation\Psr\Container\TypeRegistryGeneratorBuilderAmphp;
+use Axtiva\FlexibleGraphql\Builder\Foundation\Psr\Container\TypeRegistryGeneratorBuilderAmphpV2;
+use Axtiva\FlexibleGraphql\Builder\Foundation\Psr\Container\TypeRegistryGeneratorBuilderFederated;
+use Axtiva\FlexibleGraphql\Builder\TypeRegistryGeneratorBuilderInterface;
+use Axtiva\FlexibleGraphqlBundle\Builder\ScopedTypeRegistryGeneratorBuilder;
+use Axtiva\FlexibleGraphqlBundle\DependencyInjection\FlexibleGraphqlExtension;
+use Axtiva\FlexibleGraphqlBundle\Resolver\DefaultResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class FlexibleGraphqlExtensionTest extends TestCase
+{
+    #[DataProvider('provideBuilderVariants')]
+    public function testTypeRegistryBuilderVariantSelection(
+        string $schemaType,
+        string $executor,
+        string $expectedBaseBuilder,
+        ?string $expectedSelectedBuilder
+    ): void {
+        $container = $this->loadExtension($schemaType, $executor);
+
+        $baseDefinition = $container->getDefinition('flexible_graphql.type_registry_generator.base_builder');
+        self::assertSame($expectedBaseBuilder, $baseDefinition->getClass());
+        self::assertDefaultResolverConfiguredOnBaseBuilder($baseDefinition->getMethodCalls());
+
+        if ($expectedSelectedBuilder === null) {
+            self::assertTrue($container->hasAlias('flexible_graphql.type_registry_generator.selected_builder'));
+            self::assertSame(
+                'flexible_graphql.type_registry_generator.base_builder',
+                (string) $container->getAlias('flexible_graphql.type_registry_generator.selected_builder')
+            );
+        } else {
+            $selectedDefinition = $container->getDefinition('flexible_graphql.type_registry_generator.selected_builder');
+            self::assertSame($expectedSelectedBuilder, $selectedDefinition->getClass());
+            $selectedBaseBuilderArgument = $selectedDefinition->getArgument('$baseBuilder');
+            self::assertInstanceOf(Reference::class, $selectedBaseBuilderArgument);
+            self::assertSame('flexible_graphql.type_registry_generator.base_builder', (string) $selectedBaseBuilderArgument);
+        }
+
+        $scopedBuilderDefinition = $container->getDefinition(TypeRegistryGeneratorBuilderInterface::class);
+        self::assertSame(ScopedTypeRegistryGeneratorBuilder::class, $scopedBuilderDefinition->getClass());
+        $builderArgument = $scopedBuilderDefinition->getArgument('$baseBuilder');
+        self::assertInstanceOf(Reference::class, $builderArgument);
+        self::assertSame('flexible_graphql.type_registry_generator.selected_builder', (string) $builderArgument);
+    }
+
+    public function testTypeRegistryScopedLocatorWiring(): void
+    {
+        $container = $this->loadExtension('graphql', 'sync');
+
+        $locatorDefinition = $container->getDefinition('flexible_graphql.type_registry.service_locator');
+        self::assertSame('Symfony\\Component\\DependencyInjection\\ServiceLocator', $locatorDefinition->getClass());
+
+        $locatorArgument = $locatorDefinition->getArgument(0);
+        self::assertInstanceOf(TaggedIteratorArgument::class, $locatorArgument);
+        $taggedArgument = $locatorArgument;
+        self::assertSame(FlexibleGraphqlExtension::TYPE_REGISTRY_SERVICE_TAG, $taggedArgument->getTag());
+        self::assertSame('service_id', $taggedArgument->getIndexAttribute());
+
+        $defaultResolverDefinition = $container->getDefinition(DefaultResolver::class);
+        self::assertArrayHasKey(FlexibleGraphqlExtension::TYPE_REGISTRY_SERVICE_TAG, $defaultResolverDefinition->getTags());
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, string|null}>
+     */
+    public static function provideBuilderVariants(): iterable
+    {
+        yield 'sync graphql' => ['graphql', 'sync', TypeRegistryGeneratorBuilder::class, null];
+        yield 'amphp v2 graphql' => ['graphql', 'amphp_v2', TypeRegistryGeneratorBuilder::class, TypeRegistryGeneratorBuilderAmphpV2::class];
+        yield 'amphp v3 federation' => ['federation', 'amphp_v3', TypeRegistryGeneratorBuilderFederated::class, TypeRegistryGeneratorBuilderAmphp::class];
+    }
+
+    private function loadExtension(string $schemaType, string $executor): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $extension = new FlexibleGraphqlExtension();
+        $extension->load([
+            [
+                'namespace' => 'App\\GraphQL',
+                'dir' => sys_get_temp_dir() . '/fgb-tests-' . uniqid('', true) . '/',
+                'schema_type' => $schemaType,
+                'schema_files' => dirname(__DIR__) . '/fixture-app/config/graphql/*.graphql',
+                'executor' => $executor,
+                'enable_preload' => false,
+                'default_resolver' => FlexibleGraphqlExtension::DEFAULT_RESOLVER_ID,
+                'template_language_version' => '8.3',
+            ],
+        ], $container);
+
+        return $container;
+    }
+
+    /**
+     * @param array<int, array{string, array<int, string>}> $methodCalls
+     */
+    private static function assertDefaultResolverConfiguredOnBaseBuilder(array $methodCalls): void
+    {
+        foreach ($methodCalls as [$methodName, $arguments]) {
+            if ($methodName === 'setDefaultFieldResolverServiceName' && ($arguments[0] ?? null) === DefaultResolver::class) {
+                return;
+            }
+        }
+
+        self::fail('Default resolver service was not configured on type-registry builder.');
+    }
+}

--- a/tests/E2e/FixtureAppConsoleTest.php
+++ b/tests/E2e/FixtureAppConsoleTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Axtiva\FlexibleGraphqlBundle\Tests\E2e;
 
+use Psr\Container\NotFoundExceptionInterface;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Contracts\Service\ServiceCollectionInterface;
 
 final class FixtureAppConsoleTest extends TestCase
 {
@@ -30,6 +35,61 @@ final class FixtureAppConsoleTest extends TestCase
         $output = $this->runConsoleCommand('flexible_graphql:generate-type-registry');
         self::assertStringContainsString($registryFile, $output);
         self::assertFileExists($registryFile);
+
+        $registryCode = (string) file_get_contents($registryFile);
+        self::assertStringContainsString('ServiceCollectionInterface', $registryCode);
+        self::assertStringNotContainsString('ContainerInterface $container', $registryCode);
+    }
+
+    public function testFixtureAppGenerationSupportsConfigurationVariantsAndFederation(): void
+    {
+        $registryFile = self::fixtureAppDir() . '/var/generated/TypeRegistry.php';
+
+        $this->runConsoleCommand('flexible_graphql:generate-type-registry', [
+            'FLEXIBLE_GRAPHQL_EXECUTOR' => 'amphp_v2',
+            'FLEXIBLE_GRAPHQL_SCHEMA_TYPE' => 'graphql',
+        ]);
+        self::assertFileExists($registryFile);
+
+        $this->runConsoleCommand('cache:clear', [
+            'FLEXIBLE_GRAPHQL_EXECUTOR' => 'sync',
+            'FLEXIBLE_GRAPHQL_SCHEMA_TYPE' => 'federation',
+        ]);
+        self::assertFileExists($registryFile);
+
+        $registryCode = (string) file_get_contents($registryFile);
+        self::assertStringContainsString('_Service(): ObjectType', $registryCode);
+        self::assertStringContainsString('directive_federation__shareable', $registryCode);
+    }
+
+    public function testGeneratedTypeRegistryUsesScopedLocatorOnly(): void
+    {
+        $registryFile = self::fixtureAppDir() . '/var/generated/TypeRegistry.php';
+        $this->runConsoleCommand('flexible_graphql:generate-type-registry');
+
+        require_once $registryFile;
+
+        $registryClass = 'App\\GraphQL\\TypeRegistry';
+        self::assertTrue(class_exists($registryClass));
+
+        $serviceId = 'flexible_graphql.default_resolver';
+        $locator = new ServiceLocator([
+            $serviceId => static fn (): object => new \stdClass(),
+        ]);
+        $registry = new $registryClass($locator);
+
+        $constructor = new ReflectionMethod($registryClass, '__construct');
+        $constructorType = $constructor->getParameters()[0]->getType();
+        self::assertInstanceOf(ReflectionNamedType::class, $constructorType);
+        self::assertSame(ServiceCollectionInterface::class, $constructorType->getName());
+
+        $getService = new ReflectionMethod($registryClass, 'getService');
+        $getService->setAccessible(true);
+
+        self::assertIsObject($getService->invoke($registry, $serviceId));
+
+        $this->expectException(NotFoundExceptionInterface::class);
+        $getService->invoke($registry, 'missing.resolver.service');
     }
 
     private static function fixtureAppDir(): string
@@ -37,12 +97,23 @@ final class FixtureAppConsoleTest extends TestCase
         return dirname(__DIR__) . '/fixture-app';
     }
 
-    private function runConsoleCommand(string $command): string
+    /**
+     * @param array<string, string> $env
+     */
+    private function runConsoleCommand(string $command, array $env = []): string
     {
         $fixtureAppDir = self::fixtureAppDir();
+        self::removeDirectory($fixtureAppDir . '/var/cache/test');
+
         $consolePath = $fixtureAppDir . '/bin/console';
+        $envPrefix = '';
+        foreach ($env as $name => $value) {
+            $envPrefix .= sprintf('%s=%s ', $name, escapeshellarg($value));
+        }
+
         $execCommand = sprintf(
-            'php %s --env=test --no-interaction %s 2>&1',
+            '%sphp %s --env=test --no-interaction %s 2>&1',
+            $envPrefix,
             escapeshellarg($consolePath),
             escapeshellarg($command)
         );
@@ -54,5 +125,29 @@ final class FixtureAppConsoleTest extends TestCase
         self::assertSame(0, $exitCode, implode(PHP_EOL, $output));
 
         return implode(PHP_EOL, $output);
+    }
+
+    private static function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+
+                continue;
+            }
+
+            unlink($item->getPathname());
+        }
+
+        rmdir($path);
     }
 }

--- a/tests/fixture-app/config/packages/flexible_graphql.php
+++ b/tests/fixture-app/config/packages/flexible_graphql.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container): void {
+    $schemaType = getenv('FLEXIBLE_GRAPHQL_SCHEMA_TYPE') ?: ($_SERVER['FLEXIBLE_GRAPHQL_SCHEMA_TYPE'] ?? $_ENV['FLEXIBLE_GRAPHQL_SCHEMA_TYPE'] ?? 'graphql');
+    $executor = getenv('FLEXIBLE_GRAPHQL_EXECUTOR') ?: ($_SERVER['FLEXIBLE_GRAPHQL_EXECUTOR'] ?? $_ENV['FLEXIBLE_GRAPHQL_EXECUTOR'] ?? 'sync');
+
     $container->extension('flexible_graphql', [
         'namespace' => 'App\\GraphQL',
         'dir' => '%kernel.project_dir%/var/generated',
-        'schema_type' => 'graphql',
+        'schema_type' => $schemaType,
         'schema_files' => '%kernel.project_dir%/config/graphql/*.graphql',
+        'executor' => $executor,
         'enable_preload' => false,
         'default_resolver' => 'flexible_graphql.default_resolver',
         'template_language_version' => '8.3',


### PR DESCRIPTION
isFinished: Yes

Implemented the story end-to-end: CI install order fixed in .github/workflows/ci.yml (composer install now runs before Symfony matrix update), TypeRegistry generation now outputs Symfony\Contracts\Service\ServiceCollectionInterface locator usage (via new wrapper builder/generator in src/Builder/ScopedTypeRegistryGeneratorBuilder.php and src/Generator/ScopedServiceCollectionTypeRegistryGenerator.php, wired in src/DependencyInjection/FlexibleGraphqlExtension.php), and DI now provides resolver tagging + dedicated scoped locator in src/Resources/config/services.yaml. Consumer docs were updated in docs/index.md to remove full-container guidance. Added test coverage in tests/DependencyInjection/FlexibleGraphqlExtensionTest.php and expanded tests/E2e/FixtureAppConsoleTest.php (config variants + federation scenario + scoped locator behavior). Verification passed with composer install, PHPUnit, PHPStan (with increased memory), and fixture console commands.

Raw feedback:
{
  "feedback": {
    "approve": true,
    "summary": "Implemented the story end-to-end: CI install order fixed in .github/workflows/ci.yml (composer install now runs before Symfony matrix update), TypeRegistry generation now outputs Symfony\\Contracts\\Service\\ServiceCollectionInterface locator usage (via new wrapper builder/generator in src/Builder/ScopedTypeRegistryGeneratorBuilder.php and src/Generator/ScopedServiceCollectionTypeRegistryGenerator.php, wired in src/DependencyInjection/FlexibleGraphqlExtension.php), and DI now provides resolver tagging + dedicated scoped locator in src/Resources/config/services.yaml. Consumer docs were updated in docs/index.md to remove full-container guidance. Added test coverage in tests/DependencyInjection/FlexibleGraphqlExtensionTest.php and expanded tests/E2e/FixtureAppConsoleTest.php (config variants + federation scenario + scoped locator behavior). Verification passed with composer install, PHPUnit, PHPStan (with increased memory), and fixture console commands."
  },
  "plan": {
    "id": "2026-03-13_11-17_ci-tests-scoped-service-locator",
    "assumptions": [
      "No Docker wrapper is available in this repository context, so verification commands were executed directly.",
      "TypeRegistry contract change is implemented bundle-locally by wrapping the upstream generator output instead of modifying vendor templates.",
      "Resolver auto-tagging should be driven by Symfony _instanceof rules in services.yaml for reliable compile-time behavior."
    ],
    "risks": [
      "Generator adaptation currently relies on deterministic string replacement in generated PHP; upstream template format changes could require updates.",
      "Scoped locator includes services tagged as TypeRegistry services by interface-based rules; if custom apps over-tag resolver-like services, locator scope may widen."
    ]
  },
  "changes": {
    "files_changed": [
      ".github/workflows/ci.yml",
      "docs/index.md",
      "src/DependencyInjection/FlexibleGraphqlExtension.php",
      "src/FlexibleGraphqlBundle.php",
      "src/Resources/config/services.yaml",
      "tests/E2e/FixtureAppConsoleTest.php",
      "tests/fixture-app/config/packages/flexible_graphql.php"
    ],
    "files_added": [
      "src/Builder/ScopedTypeRegistryGeneratorBuilder.php",
      "src/Generator/ScopedServiceCollectionTypeRegistryGenerator.php",
      "tests/DependencyInjection/FlexibleGraphqlExtensionTest.php",
      "docs/retro.md"
    ],
    "notes": [
      "Introduced flexible_graphql.type_registry.service_locator as a dedicated service locator keyed by service id via tagged iterator/locator pattern.",
      "Kept existing command API unchanged while expanding fixture configurability through env-driven schema_type/executor in fixture-app config.",
      "Retained federation representation wiring in process() while moving resolver tagging responsibility to _instanceof service configuration."
    ]
  },
  "verification": {
    "commands": [
      {
        "cmd": "composer install --no-interaction --prefer-dist",
        "ok": true,
        "note": "Dependencies installed from lock file."
      },
      {
        "cmd": "vendor/bin/phpunit -c phpunit.xml.dist",
        "ok": true,
        "note": "All tests passed (7 tests)."
      },
      {
        "cmd": "vendor/bin/phpstan analyse -c phpstan.neon.dist",
        "ok": false,
        "note": "Initial run failed due PHP memory limit (128M)."
      },
      {
        "cmd": "vendor/bin/phpstan analyse -c phpstan.neon.dist --memory-limit=512M",
        "ok": true,
        "note": "Static analysis passed with increased memory limit."
      },
      {
        "cmd": "php tests/fixture-app/bin/console cache:clear --env=test --no-interaction",
        "ok": true,
        "note": "Fixture app cache warm command succeeded."
      },
      {
        "cmd": "php tests/fixture-app/bin/console flexible_graphql:generate-type-registry --env=test --no-interaction",
        "ok": true,
        "note": "Fixture app TypeRegistry generation command succeeded."
      }
    ],
    "could_not_run": []
  },
  "retro": {
    "written": true,
    "path": "docs/retro.md"
  },
  "blockers": []
}