### PR TITLE
Add support for PHP 8.3+ and integrate AMPHP executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.3']
+        php-version: ['8.3', '8.4', '8.5']
         symfony-version: ['6.4.*', '7.*', '8.*']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.1.0
+
+- extend php version support
+- add support php v8.3+
+- integrate ampphp executor
+
 3.0.0
 
 - Upgrade base lib to 3.0 with breaking changes

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Symfony bundle for [Flexible Graphql PHP](https://github.com/axtiva/flexible-gra
 - Fast integration to any project without breaking changes
 - Lazy loading on schema definition
 - Apollo Federation Support
+- Amphp v3 support for async executions
 - Executable directives
 - Support symfony native opcache preload file generation
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require": {
     "php": "^8.3",
-    "axtiva/flexible-graphql-php": "^3.0.1",
+    "axtiva/flexible-graphql-php": "^3.0.2",
     "symfony/console": "^6.4 | ^7.0 | ^8.0",
     "symfony/config": "^6.4 | ^7.0 | ^8.0",
     "symfony/dependency-injection": "^6.4 | ^7.0 | ^8.0",
@@ -26,6 +26,10 @@
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "^12"
+    "phpunit/phpunit": "^12",
+    "amphp/amp": "^3"
+  },
+  "suggest": {
+    "amphp/amp": "Needed for async execution support"
   }
 }

--- a/src/Command/GenerateFieldResolverCommand.php
+++ b/src/Command/GenerateFieldResolverCommand.php
@@ -29,7 +29,7 @@ class GenerateFieldResolverCommand extends Command
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('generate field resolver')

--- a/src/Command/GenerateScalarResolverCommand.php
+++ b/src/Command/GenerateScalarResolverCommand.php
@@ -29,7 +29,7 @@ class GenerateScalarResolverCommand extends Command
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('generate custom scalar resolver')

--- a/src/Command/GenerateTypeRegistryCommand.php
+++ b/src/Command/GenerateTypeRegistryCommand.php
@@ -31,7 +31,7 @@ class GenerateTypeRegistryCommand extends Command
         $this->codeGeneratorBuilder = $codeGeneratorBuilder;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('generate type registry class for lazy load schema')

--- a/src/DependencyInjection/FlexibleGraphqlExtension.php
+++ b/src/DependencyInjection/FlexibleGraphqlExtension.php
@@ -260,28 +260,28 @@ class FlexibleGraphqlExtension extends Extension implements CompilerPassInterfac
                 new Reference(TypeRegistryGeneratorBuilderInterface::class),
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
-            ->addTag('console.command', ['command' => GenerateTypeRegistryCommand::getDefaultName()]);
+            ->addTag('console.command');
 
         $container->register(GenerateDirectiveResolverCommand::class)
             ->setArguments([
                 $config['schema_files'],
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
-            ->addTag('console.command', ['command' => GenerateDirectiveResolverCommand::getDefaultName()]);
+            ->addTag('console.command');
 
         $container->register(GenerateFieldResolverCommand::class)
             ->setArguments([
                 $config['schema_files'],
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
-            ->addTag('console.command', ['command' => GenerateFieldResolverCommand::getDefaultName()]);
+            ->addTag('console.command');
 
         $container->register(GenerateScalarResolverCommand::class)
             ->setArguments([
                 $config['schema_files'],
                 new Reference(CodeGeneratorBuilderInterface::class),
             ])
-            ->addTag('console.command', ['command' => GenerateScalarResolverCommand::getDefaultName()]);
+            ->addTag('console.command');
     }
 
     /**

--- a/tests/DependencyInjection/FlexibleGraphqlExtensionTest.php
+++ b/tests/DependencyInjection/FlexibleGraphqlExtensionTest.php
@@ -91,6 +91,7 @@ final class FlexibleGraphqlExtensionTest extends TestCase
     {
         yield 'sync graphql' => ['graphql', 'sync', TypeRegistryGeneratorBuilder::class, null];
         yield 'amphp v2 graphql' => ['graphql', 'amphp_v2', TypeRegistryGeneratorBuilder::class, TypeRegistryGeneratorBuilderAmphpV2::class];
+        yield 'amphp v3 graphql' => ['graphql', 'amphp_v3', TypeRegistryGeneratorBuilder::class, TypeRegistryGeneratorBuilderAmphp::class];
         yield 'amphp v3 federation' => ['federation', 'amphp_v3', TypeRegistryGeneratorBuilderFederated::class, TypeRegistryGeneratorBuilderAmphp::class];
     }
 

--- a/tests/E2e/FixtureAppConsoleTest.php
+++ b/tests/E2e/FixtureAppConsoleTest.php
@@ -62,6 +62,22 @@ final class FixtureAppConsoleTest extends TestCase
         self::assertStringContainsString('directive_federation__shareable', $registryCode);
     }
 
+    public function testFixtureAppGenerationSupportsAmphpV3Executor(): void
+    {
+        $registryFile = self::fixtureAppDir() . '/var/generated/TypeRegistry.php';
+
+        $this->runConsoleCommand('flexible_graphql:generate-type-registry', [
+            'FLEXIBLE_GRAPHQL_EXECUTOR' => 'amphp_v3',
+            'FLEXIBLE_GRAPHQL_SCHEMA_TYPE' => 'graphql',
+        ]);
+        self::assertFileExists($registryFile);
+
+        $registryCode = (string) file_get_contents($registryFile);
+        self::assertStringContainsString('\Amp\async(', $registryCode, 'AMP v3 executor must wrap resolvers with \Amp\async()');
+        self::assertStringNotContainsString('\Amp\call(', $registryCode, 'AMP v3 executor must not use \Amp\call() (that is the v2 API)');
+        self::assertStringContainsString('ServiceCollectionInterface', $registryCode);
+    }
+
     public function testGeneratedTypeRegistryUsesScopedLocatorOnly(): void
     {
         $registryFile = self::fixtureAppDir() . '/var/generated/TypeRegistry.php';
@@ -84,7 +100,6 @@ final class FixtureAppConsoleTest extends TestCase
         self::assertSame(ServiceCollectionInterface::class, $constructorType->getName());
 
         $getService = new ReflectionMethod($registryClass, 'getService');
-        $getService->setAccessible(true);
 
         self::assertIsObject($getService->invoke($registry, $serviceId));
 


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the project, focusing on extending PHP version support, integrating async execution with amphp v3, and improving compatibility and testing. The update also includes some minor code quality improvements and dependency updates.

**Key changes:**

**Platform and Dependency Support:**
- Extended PHP version support to include PHP 8.3, 8.4, and 8.5 in the CI workflow and updated the `composer.json` to require PHP ^8.3 and `axtiva/flexible-graphql-php` ^3.0.2. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL12-R12) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L18-R18)
- Added `amphp/amp` as a development dependency and suggested package for async execution support.
- Updated the changelog to reflect support for new PHP versions, ampphp executor integration, and other enhancements.

**Async Execution and amphp v3 Integration:**
- Added support for amphp v3 executor, including a new test to ensure generated code wraps resolvers with `\Amp\async()` and not the deprecated `\Amp\call()`.
- Updated test provider to include amphp v3 variants for both GraphQL and federation modes.

**Symfony Console Command Registration:**
- Simplified console command registration in the dependency injection extension by removing explicit command name tags, relying on Symfony's default command name discovery.
- Added explicit `void` return type to `configure()` methods in command classes for better code clarity and type safety. [[1]](diffhunk://#diff-bb4a90e85825b81021c828c5023ae17ceb5bda04856e7fe13668c868cb170e78L32-R32) [[2]](diffhunk://#diff-f191df08a532a644742e76af621de18967a79f33b8a9da04ebc27de3f3854166L32-R32) [[3]](diffhunk://#diff-43bd1cbc9c2aa4a7b5f9921b40974019827cb90646c29013d10ddb1b8e5f90d8L34-R34)